### PR TITLE
fix: 메인 액티비티에서 API 호출 순서 변경 및 공지사항 자세히 보기 부분 수정

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -273,7 +273,7 @@
         <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_home_day.xml" value="0.19490740740740742" />
         <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_home_month.xml" value="0.19490740740740742" />
         <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_new_badge_dialog.xml" value="0.19490740740740742" />
-        <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_notice.xml" value="0.19490740740740742" />
+        <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_notice.xml" value="0.4" />
         <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_onboarding_first.xml" value="0.19490740740740742" />
         <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_setting.xml" value="0.19490740740740742" />
         <entry key="..\:/Users/kysle/AndroidStudioProjects/Footprint-Android/app/src/main/res/layout/fragment_update_dialog.xml" value="0.264" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         applicationId "com.footprint.footprint"
         minSdk 26
         targetSdk 31
-        versionCode 6
+        versionCode 7
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/footprint/footprint/ui/dialog/NoticeDialogFragment.kt
+++ b/app/src/main/java/com/footprint/footprint/ui/dialog/NoticeDialogFragment.kt
@@ -10,11 +10,9 @@ import android.view.Window
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
-import com.footprint.footprint.R
 import com.footprint.footprint.data.dto.NoticeDto
 import com.footprint.footprint.databinding.FragmentNoticeDialogBinding
 import com.footprint.footprint.ui.main.home.HomeFragmentDirections
-import com.footprint.footprint.ui.setting.NoticeDetailFragmentDirections
 import com.footprint.footprint.utils.DialogFragmentUtils
 import com.footprint.footprint.utils.addReadNoticeList
 import com.google.gson.Gson
@@ -28,7 +26,6 @@ class NoticeDialogFragment() : DialogFragment() {
 
     interface MyDialogCallback {
         fun isDismissed()
-        fun showingDetail()
     }
 
     fun setMyDialogCallback(myDialogCallback: MyDialogCallback) {
@@ -57,20 +54,11 @@ class NoticeDialogFragment() : DialogFragment() {
         // 자세히 보기 클릭 시,
         binding.noticeDialogDetailTv.setOnClickListener {
             addReadNoticeList(notice.noticeIdx) // 읽은 공지사항 리스트에 추가
-
             dismiss()
-            myDialogCallback.isDismissed()
 
             // 개별 공지 화면으로 이동
-            lateinit var action: NavDirections
-
-            if (findNavController().currentDestination!!.id == R.id.homeFragment) // 홈프래그먼트 -> 자세히 보기
-                action = HomeFragmentDirections.actionHomeFragmentToNoticeDetailFragment(notice.noticeIdx.toString())
-            else if (findNavController().currentDestination!!.id == R.id.noticeDetailFragment) // 자세히 보기 -> 자세히 보기
-                action = NoticeDetailFragmentDirections.actionNoticeDetailFragmentToNoticeDetailFragment(notice.noticeIdx.toString())
-
+            val action: NavDirections = HomeFragmentDirections.actionHomeFragmentToNoticeDetailFragment(notice.noticeIdx.toString())
             findNavController().navigate(action)
-            myDialogCallback.showingDetail()
         }
 
         return binding.root

--- a/app/src/main/java/com/footprint/footprint/ui/error/ErrorActivity.kt
+++ b/app/src/main/java/com/footprint/footprint/ui/error/ErrorActivity.kt
@@ -2,6 +2,7 @@ package com.footprint.footprint.ui.error
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Paint
 import android.net.Uri
 import android.os.Bundle
@@ -9,6 +10,7 @@ import android.view.View
 import com.footprint.footprint.databinding.ActivityErrorBinding
 import com.footprint.footprint.ui.BaseActivity
 import com.footprint.footprint.ui.main.MainActivity
+import com.footprint.footprint.utils.LogUtils
 import com.footprint.footprint.utils.getJwt
 
 class ErrorActivity : BaseActivity<ActivityErrorBinding>(ActivityErrorBinding::inflate) {
@@ -69,11 +71,7 @@ class ErrorActivity : BaseActivity<ActivityErrorBinding>(ActivityErrorBinding::i
                 putExtra(Intent.EXTRA_TEXT, content)
             }
 
-        if (intent.resolveActivity(packageManager) != null) {
-            startActivity(Intent.createChooser(intent, "메일 전송하기"))
-        } else {
-          showToast("메일을 전송할 수 없습니다.")
-        }
+        startActivity(intent)
     }
 
 }

--- a/app/src/main/java/com/footprint/footprint/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/footprint/footprint/ui/setting/SettingFragment.kt
@@ -352,6 +352,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(FragmentSettingBind
                     googleUnlink()
                 }
                 reset()
+                removeOnboarding()
             }
         })
 

--- a/app/src/main/java/com/footprint/footprint/utils/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/footprint/footprint/utils/SharedPreferenceManager.kt
@@ -19,6 +19,13 @@ fun saveOnboarding(onboardingStatus: Boolean){
 
 fun getOnboarding() = mSharedPreferences.getBoolean("onboarding", false)
 
+fun removeOnboarding(){
+    val editor = mSharedPreferences.edit()
+
+    editor.remove("onboarding")
+    editor.apply()
+}
+
 fun saveBackgroundGPS(backgroundGPSStatus: Boolean) {
     val editor = mSharedPreferences.edit()
 
@@ -148,12 +155,14 @@ fun removeNotification(){
     editor.apply()
 }
 
-/*초기화: loginStatus, PWD, JWT, Notification 초기화 */
+/*초기화: loginStatus, PWD, JWT, Notification, NoticeList 초기화 */
 fun reset(){
     removeLoginStatus()
-    removePWD()
     removeJwt()
+
+    removePWD()
     removeNotification()
+    removeReadNoticeList()
 }
 
 /* 주요 공지 */

--- a/app/src/main/res/layout/fragment_notice.xml
+++ b/app/src/main/res/layout/fragment_notice.xml
@@ -73,19 +73,20 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/black_light"
-            android:layout_marginEnd="8dp"
+            android:layout_marginHorizontal="4dp"
             style="@style/tv_body_b_14"/>
         <TextView
             android:id="@+id/notice_page2_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="4dp"
             style="@style/tv_body_b_14"/>
         <TextView
             android:id="@+id/notice_page3_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/black_light"
-            android:layout_marginStart="8dp"
+            android:layout_marginHorizontal="4dp"
             style="@style/tv_body_b_14"/>
 
         <ImageView
@@ -105,7 +106,8 @@
         android:layout_height="0dp"
         android:background="@color/white_light"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/notice_tb" />
+        app:layout_constraintTop_toBottomOf="@id/notice_tb"
+        android:visibility="gone"/>
 
     <ProgressBar
         android:id="@+id/notice_loading_pb"
@@ -115,7 +117,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"/>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -248,9 +248,6 @@
         <argument
             android:name="idx"
             app:argType="string" />
-        <action
-            android:id="@+id/action_noticeDetailFragment_to_noticeDetailFragment"
-            app:destination="@id/noticeDetailFragment" />
     </fragment>
 
 


### PR DESCRIPTION
- 메인 액티비티에서 API 호출 순서 수정 (공지사항->이달의뱃지)
- 공지사항 자세히 보기로 이동 시, 후에 다시 홈화면 돌아오면 남은 공지사항 보여주도록 수정